### PR TITLE
ユーザーによるカード追加機能と特典情報の関連付け

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :tel])
   end
 
   def ensure_login

--- a/app/controllers/benefit_lists_controller.rb
+++ b/app/controllers/benefit_lists_controller.rb
@@ -7,10 +7,15 @@ class BenefitListsController < ApplicationController
 
   def create
     @benefit_list = BenefitList.create(benefit_list_params)
+    @benefit = Benefit.create(benefit_list_id: @benefit_list.id)
+    @cards = Card.where(card_list_id: @benefit_list.card_list_id)
+    @cards.each do |card|
+      @cards_benefits = CardsBenefit.create(card_id: card.id, benefit_id: @benefit.id)
+    end
     flash[:notice] = "特典を追加しました"
     redirect_to admin_card_list_index_path(current_admin.id)
   end
-  
+
   def edit
   end
 

--- a/app/controllers/card_lists_controller.rb
+++ b/app/controllers/card_lists_controller.rb
@@ -30,6 +30,13 @@ class CardListsController < ApplicationController
     end
   end
 
+  def destroy
+    @card_list = CardList.find(params[:id].to_i)
+    @card_list.destroy
+    flash[:alert] = "カードを削除しました"
+    redirect_to action: :new
+  end
+
   private
 
   def relation_params

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -9,7 +9,7 @@ class CardsController < ApplicationController
   end
 
   def new
-    @user_cards = Card.includes(:user)
+    @user_cards = Card.where(user_id: current_user.id)
     @card_lists = CardList.all
 
     ids = []
@@ -18,12 +18,22 @@ class CardsController < ApplicationController
     end
     rest_ids = @card_lists.ids - ids
     @cards = CardList.where(id: rest_ids)
+
+    @benefit_lists = BenefitList.where(card_list_id: @cards.ids)
   end
 
   def create
     @card_list = CardList.find(params[:card_list_id])
     @card = Card.create(card_list_id: @card_list.id, admin_id: @card_list.admin_id, relation_id: @card_list.relation.id, user_id: current_user.id)
 
+    benefit_lists = []
+    @benefit_lists = benefit_params.keys.each do |id|
+      benefit_lists << BenefitList.find(id)
+    end
+    benefit_lists.each do |benefit_list|
+      @benefit = Benefit.create(benefit_list_id: benefit_list.id)
+      @cards_benefits = CardsBenefit.create(card_id: @card.id, benefit_id: @benefit.id)
+    end
     flash[:notice] = "カードを追加しました"
     redirect_to action: :new
   end
@@ -48,6 +58,10 @@ class CardsController < ApplicationController
 
   def card_params
     params.require(:card).permit(:point, :user_id, :admin_id, :relation_id)
+  end
+
+  def benefit_params
+    params.permit(benefit_lists: [:benefit_description])[:benefit_lists]
   end
 
 end

--- a/app/models/benefit.rb
+++ b/app/models/benefit.rb
@@ -1,5 +1,5 @@
 class Benefit < ApplicationRecord
   belongs_to :benefit_list
-  has_many :cards_benefits
+  has_many :cards_benefits, dependent: :delete_all
   has_many :cards, through: :cards_benefits
 end

--- a/app/models/benefit_list.rb
+++ b/app/models/benefit_list.rb
@@ -1,4 +1,4 @@
 class BenefitList < ApplicationRecord
   belongs_to :card_list, optional: true
-  has_many :benefits
+  has_many :benefits, dependent: :destroy
 end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -3,8 +3,8 @@ class Card < ApplicationRecord
   belongs_to :admin
   belongs_to :relation
   belongs_to :card_list, optional: true
-  has_many :cards_benefits
+  has_many :cards_benefits, dependent: :delete_all
   has_many :benefits, through: :cards_benefits
-  has_many :cards_coupons
+  has_many :cards_coupons, dependent: :delete_all
   has_many :coupons, through: :cards_coupons
 end

--- a/app/models/card_list.rb
+++ b/app/models/card_list.rb
@@ -1,7 +1,7 @@
 class CardList < ApplicationRecord
   belongs_to :admin
   has_one :relation
-  has_many :cards
-  has_many :benefit_lists
-  has_many :coupon_lists
+  has_many :cards, dependent: :destroy
+  has_many :benefit_lists, dependent: :destroy
+  has_many :coupon_lists, dependent: :destroy
 end

--- a/app/views/card_lists/index.html.haml
+++ b/app/views/card_lists/index.html.haml
@@ -31,7 +31,7 @@
               .description
                 = coupon.description
               .expiration
-                有効期限: #{coupon.expiration.strftime("%Y/%m/%d")}
+                有効期限: #{coupon.expiration.try(:strftime, "%Y/%m/%d")}
               .show-contents__middle__coupons__info--edit
                 = link_to '編集', edit_admin_card_list_coupon_list_path(@card_list.admin_id, @card_list.id, coupon.id), class: "btn btn-warning"
               .show-contents__middle__coupons__info--destroy

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -1,7 +1,7 @@
 .container
-  - if user_signed_in?
-    .index-contents
-      - @cards.each do |card|
+  .index-contents
+    - @cards.each do |card|
+      - if user_signed_in? && current_user.id == card.user_id
         .content-card
           %a{ href: "/cards/#{card.id}", class: "content-card__image"}
             = image_tag "/images/IMG_5385.jpg"
@@ -9,5 +9,3 @@
             %li.content-card__info__name= card.relation.name
             %li.content-card__info__point 現在のポイント: #{card.point}
           = link_to '削除', user_card_path(current_user.id, card.id), method: :delete, class: "content-card__delete btn btn-danger"
-  - if admin_signed_in?
-    .index-contents

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -8,7 +8,7 @@
           %li.content-card__info__coupon クーポン: #{card_list.coupon_lists[0].description}
         = form_with(url: user_cards_path(current_user.id), local: true, class: "admin-card__form") do |form|
           = form.hidden_field :card_list_id, value: "#{card_list.id}"
-          = form.hidden_field :benefit_description, value: "#{card_list.benefit_lists[0].description}"
-          = form.hidden_field :coupon_description, value: "#{card_list.coupon_lists[0].description}"
-          = form.hidden_field :coupon_expiration, value: "#{card_list.coupon_lists[0].expiration}"
+          - card_list.benefit_lists.each do |benefit_list|
+            = fields_for "benefit_lists[]", benefit_list do |field|
+              = field.hidden_field :benefit_description, value: "#{benefit_list.description}"
           = form.submit "追加", class: "btn btn-success"

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -28,5 +28,10 @@
             = f.label :password_confirmation
           .field-input
             = f.password_field :password_confirmation, autocomplete: "off"
+        .field
+          .field-label
+            = f.label :TEL
+          .field-input
+            = f.text_field :tel
         .actions
           = f.submit "Create Account", class: 'btn'


### PR DESCRIPTION
# What
- ユーザーによるカード作成機能を実装した
- カードを作成した際に、そのカード情報に紐づく特典情報も一括で表示させるようにした
- カード一覧画面にユーザーが登録していないカードのみを表示させるようにした
- カードの追加、削除に応じてマイカードの表示内容とカード一覧画面の表示内容を適応させるようにした
- 管理者によるカード情報の変更に伴ってユーザーが持っているカード情報も変更されるようにした

# Why
- ユーザーがカードを作成したときに特典情報も合わせて表示させるため
- カード一覧画面とマイカードのページで臨機応変に表示内容を変えるため
- 管理者が変えた情報に基づいてユーザーが持っているカード情報も変更されるようにするため