### PR TITLE
ログイン機能のアップデート

### DIFF
--- a/app/controllers/admins/registrations_controller.rb
+++ b/app/controllers/admins/registrations_controller.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 class Admins::RegistrationsController < Devise::RegistrationsController
+  before_action :user_login?
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  def user_login?
+    if current_user
+      flash[:alert] = "管理者登録をするためには、ログイン中のユーザーをログアウトしてください"
+      redirect_to user_cards_path(current_user.id)
+    end
+  end
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/controllers/admins/sessions_controller.rb
+++ b/app/controllers/admins/sessions_controller.rb
@@ -4,9 +4,9 @@ class Admins::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
-  def new
-    @admin = Admin.new
-  end
+  # def new
+  #   @admin = Admin.new
+  # end
 
   # POST /resource/sign_in
   # def create

--- a/app/controllers/admins/sessions_controller.rb
+++ b/app/controllers/admins/sessions_controller.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class Admins::SessionsController < Devise::SessionsController
+  before_action :user_login?
   # before_action :configure_sign_in_params, only: [:create]
+
+  def user_login?
+    if current_user
+      flash[:alert] = "管理者としてログインするためには、ログイン中のユーザーをログアウトしてください"
+      redirect_to user_cards_path(current_user.id)
+    end
+  end
 
   # GET /resource/sign_in
   # def new

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,16 @@ class ApplicationController < ActionController::Base
       redirect_to top_cards_path
     end
   end
+
+  def after_sign_in_path_for(resource)
+    if current_user
+      user_cards_path(current_user.id)
+    else
+      admin_card_list_index_path(current_admin.id)
+    end
+  end
+
+  def after_sign_out_path_for(resource)
+    top_cards_path
+  end
 end

--- a/app/controllers/card_lists_controller.rb
+++ b/app/controllers/card_lists_controller.rb
@@ -1,4 +1,6 @@
 class CardListsController < ApplicationController
+  before_action :admin_card_list_has?, only: [:index]
+
   def index
     @card_list = CardList.find_by(admin_id: current_admin.id)
   end
@@ -53,6 +55,12 @@ class CardListsController < ApplicationController
 
   def coupon_params
     params.require(:coupon_list).permit(:description, :expiration).merge(card_list_id: @card_list.id)
+  end
+
+  def admin_card_list_has?
+    unless current_admin.card_list
+      redirect_to new_admin_card_list_path(current_admin.id)
+    end
   end
 
 end

--- a/app/controllers/card_lists_controller.rb
+++ b/app/controllers/card_lists_controller.rb
@@ -1,5 +1,7 @@
 class CardListsController < ApplicationController
-  before_action :admin_card_list_has?, only: [:index]
+  before_action :admin_sign_up, only: [:index]
+  before_action :admin_card_list_has?, only: [:new]
+
 
   def index
     @card_list = CardList.find_by(admin_id: current_admin.id)
@@ -57,9 +59,15 @@ class CardListsController < ApplicationController
     params.require(:coupon_list).permit(:description, :expiration).merge(card_list_id: @card_list.id)
   end
 
-  def admin_card_list_has?
+  def admin_sign_up
     unless current_admin.card_list
       redirect_to new_admin_card_list_path(current_admin.id)
+    end
+  end
+
+  def admin_card_list_has?
+    if current_admin.card_list
+      redirect_to admin_card_list_index_path(current_admin.id)
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :admin_login?
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  def admin_login?
+    if current_admin
+      flash[:alert] = "ユーザー登録をするためには、ログイン中の管理者をログアウトしてください"
+      redirect_to admin_card_list_index_path(current_admin.id)
+    end
+  end
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,9 +4,9 @@ class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
-  def new
-    @user = User.new
-  end
+  # def new
+  #   @user = User.new
+  # end
 
   # POST /resource/sign_in
   # def create

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  before_action :admin_login?
   # before_action :configure_sign_in_params, only: [:create]
+
+  def admin_login?
+    if current_admin
+      flash[:alert] = "ユーザーとしてログインするためには、ログイン中の管理者をログアウトしてください"
+      redirect_to admin_card_list_index_path(current_admin.id)
+    end
+  end
 
   # GET /resource/sign_in
   # def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,27 +1,4 @@
 module ApplicationHelper
-  def user_resource_name
-    :user
-  end
-
-  def user_resource
-    @resource ||= User.new
-  end
-
-  def user_devise_mapping
-    @devise_mapping ||= Devise.mappings[:user]
-  end
-
-  def admin_resource_name
-    :admin
-  end
-
-  def admin_resource
-    @resource ||= Admin.new
-  end
-
-  def admin_devise_mapping
-    @devise_mapping ||= Devise.mappings[:admin]
-  end
 
   require 'chunky_png'
 

--- a/app/views/admins/shared/_links.html.haml
+++ b/app/views/admins/shared/_links.html.haml
@@ -1,19 +1,19 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(admin_resource_name)
+  = link_to "Log in", new_session_path(resource_name)
   %br/
-- if admin_devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(admin_resource_name)
+- if devise_mapping.registerable? && controller_name != 'registrations'
+  = link_to "Sign up", new_registration_path(resource_name)
   %br/
-- if admin_devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(admin_resource_name)
+- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  = link_to "Forgot your password?", new_password_path(resource_name)
   %br/
-- if admin_devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(admin_resource_name)
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
+  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
   %br/
-- if admin_devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "Didn't receive unlock instructions?", new_unlock_path(admin_resource_name)
+- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
   %br/
-- if admin_devise_mapping.omniauthable?
-  - admin_resource_class.omniauth_providers.each do |provider|
-    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(admin_resource_name, provider)
+- if devise_mapping.omniauthable?
+  - resource_class.omniauth_providers.each do |provider|
+    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
     %br/

--- a/app/views/cards/top.html.haml
+++ b/app/views/cards/top.html.haml
@@ -34,5 +34,5 @@
         &emsp;集客やマーケティングに活用できる
       .admin-contents__merit__image= image_tag "/images/graph_up.png"
   %h2.register#register 登録はこちらから
-  = link_to "ユーザーの方はこちら", new_session_path(user_resource_name), class: "btn btn-success"
-  = link_to "事業主の方はこちら", new_session_path(admin_resource_name), class: "btn btn-warning"
+  = link_to "ユーザーの方はこちら", new_user_registration_path, class: "btn btn-success"
+  = link_to "事業主の方はこちら", new_admin_registration_path, class: "btn btn-warning"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,7 +23,7 @@
                 = link_to "カード一覧検索", new_user_card_path(current_user.id), class: 'btn'
               %li.header-contents__content<
                 = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'btn'
-          -if admin_signed_in?
+          -elsif admin_signed_in?
             %ul.header-contents
               - if current_admin.card_list
                 %li.header-contents__content<
@@ -33,6 +33,12 @@
                   = link_to "カードの作成", new_admin_card_list_path(current_admin.id), class: 'btn'
               %li.header-contents__content<
                 = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'btn'
+          -else
+            %ul.header-contents
+              %li.header-contents__content<
+                = link_to "ユーザーログイン", new_user_session_path, class: 'btn'
+              %li.header-contents__content<
+                = link_to "管理者ログイン", new_admin_session_path, class: 'btn'
     .main-contents
       = render 'layouts/notifications'
       = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,7 +32,7 @@
                 %li.header-contents__content<
                   = link_to "カードの作成", new_admin_card_list_path(current_admin.id), class: 'btn'
               %li.header-contents__content<
-                = link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'btn'
+                = link_to "ログアウト", destroy_admin_session_path, method: :delete, class: 'btn'
           -else
             %ul.header-contents
               %li.header-contents__content<

--- a/app/views/users/shared/_links.html.haml
+++ b/app/views/users/shared/_links.html.haml
@@ -1,19 +1,19 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(user_resource_name)
+  = link_to "Log in", new_session_path(resource_name)
   %br/
-- if user_devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(user_resource_name)
+- if devise_mapping.registerable? && controller_name != 'registrations'
+  = link_to "Sign up", new_registration_path(resource_name)
   %br/
-- if user_devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(user_resource_name)
+- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  = link_to "Forgot your password?", new_password_path(resource_name)
   %br/
-- if user_devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(user_resource_name)
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
+  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
   %br/
-- if user_devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to "Didn't receive unlock instructions?", new_unlock_path(user_resource_name)
+- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
   %br/
-- if user_devise_mapping.omniauthable?
-  - user_resource_class.omniauth_providers.each do |provider|
-    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(user_resource_name, provider)
+- if devise_mapping.omniauthable?
+  - resource_class.omniauth_providers.each do |provider|
+    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
     %br/


### PR DESCRIPTION
# What
- ユーザーがログインしてる時に管理者の登録やログインができないように設定した
- 管理者側も同様
- それぞれのサインアップ後、ログイン後の画面遷移を設定した
- 管理者でログインした場合は、既に作成済みのカードの有無でパスを変更した

# Why
- 同時にログインできてしまうと複雑なビューになってしまうため
- ログイン後に適切な画面に遷移する方がUI/UXが高いため