### PR TITLE
db.envの記述削除

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,3 @@ spec/fixtures/*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
-
-#DB password
-environments/db.env

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,3 @@
 public/images/*
 public/uploads/*
 spec/fixtures/*
-
-#DB password
-environments/db.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '2'
 services:
   db:
     image: mysql:5.6
-    env_file:
-      - ./environments/db.env
     volumes:
       - mysql-data:/var/lib/mysql
     ports:
@@ -13,8 +11,6 @@ services:
     tty: true
     stdin_open: true
     build: .
-    env_file:
-      - ./environments/db.env
     command: bundle exec puma -C config/puma.rb
     volumes:
       - .:/myproject


### PR DESCRIPTION
# What
- docker-composeでdb.envを参照していた記述を削除した
- 空のdb.envファイルを作った

# Why
- gitignoreしていると参照できなくてgit cloneした時にエラーになるため
- からのファイルがないとcredentialsができないため