### PR TITLE
ユーザー一覧画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import "cards/show";
 @import "cards/new";
 @import "cards/update";
+@import "cards/users";
 @import "card_lists/index";
 @import "card_lists/show";
 @import "card_lists/new";

--- a/app/assets/stylesheets/cards/_edit.scss
+++ b/app/assets/stylesheets/cards/_edit.scss
@@ -85,8 +85,21 @@
         }
       }
       &__submit {
-        text-align: center;
+        display: flex;
+        justify-content: space-around;
+        width: 50%;
+        margin: 0 auto;
         margin-bottom: 5%;
+        .form-submit {
+          font-size: calc(5px + 1vw);
+          padding: 1%;
+          height: 5%;
+        }
+        .card__delete {
+          font-size: calc(5px + 1vw);
+          padding: 1%;
+          height: 5%;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/cards/_users.scss
+++ b/app/assets/stylesheets/cards/_users.scss
@@ -1,0 +1,38 @@
+.user-cards-contents {
+  width: 95%;
+  margin: 0 auto;
+  h2 {
+    text-align: center;
+    margin: 5% 0;
+    font-size: calc(15px + 1vw);
+  }
+  .table {
+    font-size: 1vw;
+    .record__header {
+      padding: 0.7%;
+      .name {
+        width: 10%;
+      }
+      .point {
+        width: 10%;
+      }
+      .benefit {
+        width: 25%;
+      }
+      .benefit-used {
+        width: 18%;
+      }
+      .coupon {
+        width: 20%;
+      }
+      .coupon-used {
+        width: 18%;
+      }
+    }
+    .record__data {
+      padding: 0.7%;
+      border-bottom: solid 1px rgba(0, 0, 0, 0.2);
+      
+    }
+  }
+}

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -74,11 +74,19 @@ class CardsController < ApplicationController
   def destroy
     @card.destroy
     flash[:alert] = "カードを削除しました"
-    redirect_to action: :index
+    if user_signed_in?
+      redirect_to action: :index
+    elsif admin_signed_in?
+      redirect_to users_cards_path
+    end
   end
 
   def search
     @cards = Card.search(params[:keyword])
+  end
+
+  def users
+    @cards = Card.where(admin_id: current_admin.id)
   end
 
   private

--- a/app/views/cards/edit.html.haml
+++ b/app/views/cards/edit.html.haml
@@ -42,7 +42,8 @@
           = form.hidden_field :admin_id, :value => @card.admin_id
           = form.hidden_field :relation_id, :value => @card.relation_id
           .card-edit__form__submit
-            = form.submit "変更", class: "form-submit btn btn-primary"
+            = form.submit "カード情報を変更", class: "form-submit btn btn-primary"
+            = link_to 'カードを削除する', user_card_path(@card.id), method: :delete, class: "card__delete btn btn-danger"
   - else
     .card-edit__alert
       %h2 カードの管理者のみ編集可能です

--- a/app/views/cards/users.html.haml
+++ b/app/views/cards/users.html.haml
@@ -1,0 +1,34 @@
+.container_overflow
+  .user-cards-contents
+    %h2 カード枚数: #{@cards.length}
+    %table.table.table-borderd
+      %tr.thead-light.record__header
+        %th.record__header.name 名前
+        %th.record__header.point ポイント
+        %th.record__header.benefit ポイント特典
+        %th.record__header.benefit-used 特典使用日
+        %th.record__header.coupon クーポン
+        %th.record__header.coupon-used クーポン使用日
+      - @cards.each do |card|
+        - benefit_length = card.benefits.length
+        - coupon_length = card.coupons.length
+        - max = [benefit_length, coupon_length].max
+        - index = 0
+        - max.times do
+          %tr.record__data
+            - if index == 0
+              %td{ rowspan: "#{max}", class: "record__data name" }= link_to "#{card.user.name}", edit_admin_card_path(current_admin.id, card.id)
+              %td{ rowspan: "#{max}", class: "record__data point" } #{card.point}
+            - if card.benefits[index].present?
+              %td.record__data.benefit #{card.benefits[index].benefit_list.description}
+              %td.record__data.benefit-used #{card.benefits[index].used_date}
+            - else
+              %td.record__data
+              %td.record__data
+            - if card.coupons[index].present?
+              %td.record__data.coupon #{card.coupons[index].coupon_list.description}
+              %td.record__data.coupon-used #{card.coupons[index].used_date}
+            - else
+              %td.record__data
+              %td.record__data
+          - index += 1

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,6 +26,8 @@
           -elsif admin_signed_in?
             %ul.header-contents
               - if current_admin.card_list
+                %li.header-contents__users<
+                  = link_to "ユーザー一覧", users_cards_path, class: 'btn'
                 %li.header-contents__content<
                   = link_to "カード情報", admin_card_list_index_path(current_admin.id), class: 'btn'
               -else 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     collection do
       get 'top'
       get 'search'
+      get 'users'
     end
   end
 


### PR DESCRIPTION
# What
- 管理者画面から見れる、カード所有ユーザー情報の一覧画面を実装した
- 一覧画面からは各ユーザーのカード情報編集ページにリンクするよう設定した
- カード編集画面でカードを削除できるよう設定した
- ユーザーがカードを削除した時と、管理者がカードを削除した時で遷移するページを変えた

# Why
- 一覧画面があった方が管理者のUI/UXが向上するため