### PR TITLE
modelのdependent修正

### DIFF
--- a/app/models/cards_benefit.rb
+++ b/app/models/cards_benefit.rb
@@ -1,4 +1,4 @@
 class CardsBenefit < ApplicationRecord
   belongs_to :card
-  belongs_to :benefit, dependent: :delete
+  belongs_to :benefit, dependent: :destroy
 end

--- a/app/models/cards_coupon.rb
+++ b/app/models/cards_coupon.rb
@@ -1,4 +1,4 @@
 class CardsCoupon < ApplicationRecord
   belongs_to :card
-  belongs_to :coupon, dependent: :delete
+  belongs_to :coupon, dependent: :destroy
 end


### PR DESCRIPTION
# What
- cards_benefitとcards_couponのdependent: :deleteを:destroyに変更した

# Why
- cardを削除した時deleteだとエラーが出る場合があったが、destroyに変えるとエラーが出なくなったため
- 出ていたエラーは外部キーが参照できないというものだった
- dependentの場合、先に削除されるのはdependent先の方？？
- だとすると、deleteだとメソッドがチェーンされないのでエラーになる？？