### PR TITLE
docker-composeの環境別設定

### DIFF
--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -8,7 +8,10 @@
         - if @card.expiration.present?
           %li.show-contents__upper__expiration 有効期限: #{@card.expiration.strftime("%Y/%m/%d")}
       .show-contents__upper__qrcode
-        = image_tag qrcode_tag "http://localhost:3000/admins/#{@card.admin_id}/cards/#{@card.id}/edit"
+        - if ENV["RAILS_ENV"] == "development"
+          = image_tag qrcode_tag "http://localhost:3000/admins/#{@card.admin_id}/cards/#{@card.id}/edit"
+        - elsif ENV["RAILS_ENV"] == "production"
+          = image_tag qrcode_tag "http://13.112.60.229/admins/#{@card.admin_id}/cards/#{@card.id}/edit"
       = link_to '削除', user_card_path(@card.id), method: :delete, class: "show-contents__upper__delete btn btn-danger"
     .show-contents__middle
       .show-contents__middle__benefits

--- a/development.yml
+++ b/development.yml
@@ -1,0 +1,36 @@
+version: '2'
+services:
+  db:
+    extends:
+      file: docker-compose.yml
+      service: db
+
+  app:
+    extends:
+      file: docker-compose.yml
+      service: app
+    tty: true
+    stdin_open: true
+    volumes:
+      - .:/myproject
+      - bundle:/usr/local/bundle
+      - public-data:/myproject/public
+      - tmp-data:/myproject/tmp
+      - log-data:/myproject/log
+    links:
+      - db
+    environment:
+      RAILS_ENV: development
+
+  web:
+    extends:
+      file: docker-compose.yml
+      service: web
+    depends_on:
+      - app
+volumes:
+  mysql-data:
+  bundle:
+  public-data:
+  tmp-data:
+  log-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,18 +8,8 @@ services:
       - "4306:3306"
 
   app:
-    tty: true
-    stdin_open: true
     build: .
     command: bundle exec puma -C config/puma.rb
-    volumes:
-      - .:/myproject
-      - bundle:/usr/local/bundle
-      - public-data:/myproject/public
-      - tmp-data:/myproject/tmp
-      - log-data:/myproject/log
-    links:
-      - db
 
   web:
     build:
@@ -29,11 +19,7 @@ services:
       - tmp-data:/myproject/tmp
     ports:
       - 80:80
-    depends_on:
-      - app
 volumes:
   mysql-data:
-  bundle:
   public-data:
   tmp-data:
-  log-data:

--- a/production.yml
+++ b/production.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+  app:
+    extends:
+      file: docker-compose.yml
+      service: app
+    volumes:
+      - public-data:/myproject/public
+      - tmp-data:/myproject/tmp
+      - log-data:/myproject/log
+    environment:
+      RAILS_ENV: production
+
+  web:
+    extends:
+      file: docker-compose.yml
+      service: web
+    depends_on:
+      - app
+volumes:
+  public-data:
+  tmp-data:
+  log-data:


### PR DESCRIPTION
# What
- docker-compose.ymlを共通ファイルの仕様に変更した
- development.ymlとproduction.ymlを作成し、開発環境用と本番環境用で設定を変えた
- production.ymlにおける変更点は以下の通り
  - binding.pryやbundleの記述削除
  - dbはRDS使用のため記述削除
  - appのvolumeでrailsファイルのマウントしない仕様に
  - environmentでRAILS_ENVをproductionに設定（development.ymlではdevelopmentに設定）
- QRコードのリンク先をENV["RAILS_ENV"]条件で分けた

# Why
- 本番環境でdocker-composeするとdevelopment環境で動いてしまうため指定できるよう設定
- 共通部分は省略した方が冗長にならなくてすむため
- 開発環境と本番環境でQRコードのURLを変える必要があったため